### PR TITLE
Add CI Team members as openstack owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,6 +10,10 @@ aliases:
     - mdbooth
     - pierreprinetti
     - stephenfin
+    - eurijon
+    - itzikb-redhat
+    - rlobillo
+    - imatza-rh
   openstack-reviewers:
     - EmilienM
     - MaysaMacedo
@@ -19,3 +23,7 @@ aliases:
     - mdbooth
     - pierreprinetti
     - stephenfin
+    - eurijon
+    - itzikb-redhat
+    - rlobillo
+    - imatza-rh


### PR DESCRIPTION
This PR intends to share shiftstack job config ownership with CI team members focused on OpenShift on OpenStack CI.

This owner aliases will be fetched by:

- https://github.com/openshift/release/blob/master/ci-operator/jobs/shiftstack/ci/OWNERS
- https://github.com/openshift/release/blob/master/ci-operator/config/shiftstack/ci/OWNERS